### PR TITLE
Local(fix): stop keypress handler accumulation; preserve modal guard.…

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/modules/circ/circulation.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/circ/circulation.tt
@@ -1197,15 +1197,21 @@
             var newin = window.open(link, 'popup', 'width=600,height=400,resizable=1,toolbar=0,scrollbars=1,top');
         }
         $(document).ready(function() {
+            let barcodeSubmitInFlight = false;
+            $('#barcode')
+                .off('keypress.preventDouble')
+                .on('keypress.preventDouble', function(event) {
+                    if (barcodeSubmitInFlight) {
+                        $('#barcodeSubmittedModal').modal();
+                        event.preventDefault();
+                    }
+                });
             $(".deletemessagelink").on("click",function(){
                 return confirm(_("Are you sure you want to delete this message? This cannot be undone."));
             });
             $('#mainform').on('submit',function() {
-                if ($("#barcode") && $("#barcode").val()) {
-                    $('#barcode').on('keypress',function(event) {
-                        $('#barcodeSubmittedModal').modal();
-                        event.preventDefault(); }
-                    );
+                if ($("#barcode").length && $("#barcode").val()) {
+                    barcodeSubmitInFlight = true;
                 }
             });
 

--- a/koha-tmpl/intranet-tmpl/prog/en/modules/circ/returns.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/circ/returns.tt
@@ -1395,6 +1395,7 @@
             .on('shown.bs.modal', function() {
                 $("#barcode").prop("disabled", false).focus();
             }).on('hidden.bs.modal', function() {
+                $("body").removeClass("nobackdrop");
                 $("#barcode").prop("disabled", false).focus();
             });
 

--- a/koha-tmpl/intranet-tmpl/prog/js/checkouts.js
+++ b/koha-tmpl/intranet-tmpl/prog/js/checkouts.js
@@ -1292,18 +1292,4 @@ $(document).ready(function() {
         $("#return-claims-table").DataTable().search("is_unresolved").draw();
     });
 
-    $("#show_all_claims").on("click", function(e){
-        e.preventDefault();
-        $(".ctrl_link").removeClass("disabled");
-        $(this).addClass("disabled");
-        $("#return-claims-table").DataTable().search("").draw();
-    });
-
-    $("#show_unresolved_claims").on("click", function (e) {
-        e.preventDefault();
-        $(".ctrl_link").removeClass("disabled");
-        $(this).addClass("disabled");
-        $("#return-claims-table").DataTable().search("is_unresolved").draw();
-    });
-
  });


### PR DESCRIPTION
… Also tidy returns modal state.

- circ/circulation.tt
  - Every successful submit attached a new `keypress` handler to `#barcode`, leading to thousands of handlers over long sessions, jank, and long GC pauses.
  - Install a single, namespaced keypress handler on `#barcode` at page load.
  - Introduce a local in-flight flag within the same `$(document).ready(... )` closure.
  - On submit (when `#barcode` has a value), set the flag.
  - The one keypress handler checks the flag; if true, it shows `#barcodeSubmittedModal` and prevents default, blocking double submissions.
  - No per-submit re-bindings; handler count stays constant.

- circ/returns.tt
  - Ensure `$("body").removeClass("nobackdrop")` on modal hide for non-blocking modals, avoiding stale page state.
  - Barcode re-enable/focus behavior remains.

- checkouts.js
  - Remove duplicate event listener declaration + attachment (likely a merge oversight).